### PR TITLE
Removed requirement for Nova ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
-        "laravel/nova": "^2.0"
+        "php": ">=7.1.0"        
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is similar to issue below for Nova inline select component:
https://github.com/kirschbaum-development/nova-inline-select/issues/1

as installation is challenging.